### PR TITLE
Fix production Vercel build

### DIFF
--- a/.github/workflows/vercel-production.yml
+++ b/.github/workflows/vercel-production.yml
@@ -20,7 +20,7 @@ jobs:
           cache: 'pnpm'
       - run: pnpm install
       - run: npx vercel pull --yes --environment=production --token ${{ secrets.VERCEL_TOKEN }}
-      - run: npx vercel build --token ${{ secrets.VERCEL_TOKEN }}
+      - run: npx vercel build --prod --token ${{ secrets.VERCEL_TOKEN }}
       - run: npx vercel deploy --prebuilt --prod --token=${{ secrets.VERCEL_TOKEN }}
         env:
           VERCEL_ORG_ID: ${{ secrets.VERCEL_ORG_ID }}


### PR DESCRIPTION
## Summary
- fix build step in production workflow so preview artifacts aren't deployed

## Testing
- `pnpm lint` *(fails: ESLint not configured)*

------
https://chatgpt.com/codex/tasks/task_e_6889510195348330a06540f361334cd4