### PR TITLE
Add spinner for loading courses

### DIFF
--- a/app/loading.tsx
+++ b/app/loading.tsx
@@ -1,3 +1,9 @@
+import Spinner from "@/components/ui/spinner"
+
 export default function Loading() {
-  return null
+  return (
+    <div className="flex min-h-screen items-center justify-center">
+      <Spinner className="h-8 w-8 text-muted-foreground" />
+    </div>
+  )
 }

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -8,6 +8,7 @@ import { Input } from "@/components/ui/input"
 import { Badge } from "@/components/ui/badge"
 import { Card, CardContent } from "@/components/ui/card"
 import { Plus, Download, Calendar, TableIcon, Search, ChevronDown, X, Minus } from "lucide-react"
+import Spinner from "@/components/ui/spinner"
 import { toast } from "@/hooks/use-toast"
 import { Popover, PopoverContent, PopoverTrigger } from "@/components/ui/popover"
 import { Checkbox } from "@/components/ui/checkbox"
@@ -1108,7 +1109,9 @@ export default function CourseTable() {
           </div>
 
           {loading ? (
-            <div className="text-center py-8">Loading courses...</div>
+            <div className="flex justify-center py-8">
+              <Spinner className="h-6 w-6 text-muted-foreground" />
+            </div>
           ) : (
             <div className="space-y-2 max-h-96 overflow-y-auto">
               {filteredCourses.map((course) => renderCourseCard(course))}

--- a/components/ui/spinner.tsx
+++ b/components/ui/spinner.tsx
@@ -1,0 +1,13 @@
+import * as React from "react"
+import { Loader2 } from "lucide-react"
+import { cn } from "@/lib/utils"
+
+export interface SpinnerProps extends React.SVGAttributes<SVGSVGElement> {}
+
+export function Spinner({ className, ...props }: SpinnerProps) {
+  return (
+    <Loader2 aria-label="Loading" className={cn("animate-spin", className)} {...props} />
+  )
+}
+
+export default Spinner


### PR DESCRIPTION
## Summary
- create reusable `Spinner` component
- show spinner while loading courses
- display spinner for global loading state

## Testing
- `pnpm build`


------
https://chatgpt.com/codex/tasks/task_e_688964e7e5508330ba5b2f9f8b8522eb