### PR TITLE
Update branding and heading

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# Yale SOM Course Picker
+# SOM Course Picker
 
 *Automatically synced with your [v0.dev](https://v0.dev) deployments*
 

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -11,9 +11,12 @@ const inter = Inter({
 })
 
 export const metadata: Metadata = {
-  title: "Yale SOM Course Table",
+  title: "SOM Course Picker",
   description: "Course selection website for Yale School of Management",
   generator: "v0.dev",
+  icons: {
+    icon: "https://som.yale.edu/themes/custom/som/images/favicons/favicon.ico",
+  },
 }
 
 export default function RootLayout({

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -421,7 +421,7 @@ const getProgramCohortBadgeClass = (color: string): string => {
   return colorMap[color.toLowerCase()] || "bg-gray-500 hover:bg-gray-500 text-white border-0"
 }
 
-// Add this function before the CourseTable component
+// Add this function before the SOMCourse component
 const getCurrentAndNextSemesters = (): string[] => {
   const now = new Date()
   const currentYear = now.getFullYear()
@@ -520,7 +520,7 @@ const ExpandableTableCell = ({ text }: { text: string }) => {
   )
 }
 
-export default function CourseTable() {
+export default function SOMCourse() {
   const [courses, setCourses] = useState<Course[]>([])
   const [scheduledCourses, setScheduledCourses] = useState<ScheduledCourse[]>([])
   const [searchTerm, setSearchTerm] = useState("")
@@ -531,7 +531,7 @@ export default function CourseTable() {
   const [selectedInstructors, setSelectedInstructors] = useState<string[]>([])
   const [selectedUnits, setSelectedUnits] = useState<string[]>([])
   const [selectedProgramCohorts, setSelectedProgramCohorts] = useState<string[]>(["Elective"])
-  // In the CourseTable component, add a new state to track expanded descriptions
+  // In the SOMCourse component, add a new state to track expanded descriptions
   const categories = React.useMemo(() => {
     const categorySet = new Set<string>()
     courses.forEach((course) => {
@@ -810,8 +810,8 @@ export default function CourseTable() {
       <header className="bg-white border-b border-gray-200 px-6 py-4">
         <div className="flex items-center justify-between">
           <div className="flex items-center space-x-4">
-            <h1 className="text-2xl font-bold text-blue-600">
-              Course<span className="text-gray-900">Table</span>
+            <h1 className="text-2xl font-bold text-gray-900">
+              <span className="text-[#000f9f]">SOM</span>Course
             </h1>
           </div>
         </div>


### PR DESCRIPTION
## Summary
- update page title and add SOM favicon
- rename `CourseTable` to `SOMCourse`
- style heading with SOM blue
- adjust README title

## Testing
- `npx vitest run`

------
https://chatgpt.com/codex/tasks/task_e_68896a51da9c8330bab8c9cb84cfde01