### PR TITLE
Update calendar layout for dynamic times and conflicts

### DIFF
--- a/app/page.tsx
+++ b/app/page.tsx
@@ -759,10 +759,6 @@ export default function SOMCourse() {
     return slots
   }, [scheduledCourses])
 
-  const maxTimeLabel = React.useMemo(
-    () => timeSlots.reduce((a, b) => (b.length > a.length ? b : a), ""),
-    [timeSlots]
-  )
 
   const scheduleStartMinutes = React.useMemo(
     () => parseTimeToMinutes(timeSlots[0] ?? "8:00 AM"),
@@ -1140,11 +1136,9 @@ export default function SOMCourse() {
                 <div className="bg-white rounded-lg border">
                   <div
                     className="grid grid-cols-6 border-b"
-                    style={{ gridTemplateColumns: 'auto repeat(5, 1fr)' }}
+                    style={{ gridTemplateColumns: 'max-content repeat(5, 1fr)' }}
                   >
-                    <div className="p-4 border-r bg-gray-50">
-                      <span className="invisible">{maxTimeLabel}</span>
-                    </div>
+                    <div className="px-2 py-1 border-r bg-gray-50"></div>
                     {DAYS.map((day, i) => (
                       <div
                         key={day}
@@ -1158,7 +1152,7 @@ export default function SOMCourse() {
 
                   <div
                     className="grid grid-cols-6 relative"
-                    style={{ minHeight: '400px', gridTemplateColumns: 'auto repeat(5, 1fr)' }}
+                    style={{ minHeight: '400px', gridTemplateColumns: 'max-content repeat(5, 1fr)' }}
                   >
                     <div className="border-r bg-gray-50">
                       {timeSlots.map((time) => (


### PR DESCRIPTION
## Summary
- adjust calendar width so time column fits text
- show calendar only between first and last class with a 1 hour buffer
- handle overlapping classes by splitting columns

## Testing
- `pnpm exec vitest run`

------
https://chatgpt.com/codex/tasks/task_e_6889886531948330a738d3ba0cd73ad6