### PR TITLE
Update calendar layout for dynamic times and conflicts

### DIFF
--- a/app/page.tsx
+++ b/app/page.tsx
@@ -763,10 +763,10 @@ export default function SOMCourse() {
   const [timeColumnWidth, setTimeColumnWidth] = React.useState<number>()
 
   React.useLayoutEffect(() => {
-    if (timeColumnRef.current) {
+    if (activeTab === "calendar" && timeColumnRef.current) {
       setTimeColumnWidth(timeColumnRef.current.getBoundingClientRect().width)
     }
-  }, [timeSlots])
+  }, [activeTab, timeSlots])
 
   const scheduleStartMinutes = React.useMemo(
     () => parseTimeToMinutes(timeSlots[0] ?? "8:00 AM"),

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -763,9 +763,26 @@ export default function SOMCourse() {
   const [timeColumnWidth, setTimeColumnWidth] = React.useState<number>()
 
   React.useLayoutEffect(() => {
-    if (activeTab === "calendar" && timeColumnRef.current) {
-      setTimeColumnWidth(timeColumnRef.current.getBoundingClientRect().width)
+    if (activeTab !== "calendar" || !timeColumnRef.current) return
+
+    const updateWidth = () => {
+      if (timeColumnRef.current) {
+        setTimeColumnWidth(timeColumnRef.current.getBoundingClientRect().width)
+      }
     }
+
+    updateWidth()
+
+    const Observer = (window as any).ResizeObserver
+    if (Observer) {
+      const observer = new Observer(updateWidth)
+      observer.observe(timeColumnRef.current)
+      return () => {
+        observer.disconnect()
+      }
+    }
+
+    return undefined
   }, [activeTab, timeSlots])
 
   const scheduleStartMinutes = React.useMemo(

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -1163,7 +1163,10 @@ export default function SOMCourse() {
 
                   <div
                     className="grid grid-cols-6 relative"
-                    style={{ minHeight: '400px', gridTemplateColumns: 'auto repeat(5, 1fr)' }}
+                    style={{
+                      height: `${timeSlots.length * TIME_SLOT_HEIGHT}px`,
+                      gridTemplateColumns: 'auto repeat(5, 1fr)'
+                    }}
                   >
                     <div className="border-r bg-gray-50" ref={timeColumnRef}>
                       {timeSlots.map((time) => (


### PR DESCRIPTION
## Summary
- adjust calendar width so time column fits text
- show calendar only between first and last class with a 1 hour buffer
- handle overlapping classes by splitting columns
- keep first row of calendar aligned by matching the width of the time column via a measured ref

## Testing
- `pnpm exec vitest run`


------
https://chatgpt.com/codex/tasks/task_e_6889886531948330a738d3ba0cd73ad6