### PR TITLE
Fix color reuse after removing scheduled courses

### DIFF
--- a/app/page.tsx
+++ b/app/page.tsx
@@ -668,7 +668,11 @@ export default function SOMCourse() {
       return
     }
 
-    const color = COLORS[scheduledCourses.length % COLORS.length]
+    const usedColors = new Set(scheduledCourses.map((c) => c.color))
+    const color =
+      COLORS.find((c) => !usedColors.has(c)) ??
+      COLORS[scheduledCourses.length % COLORS.length]
+
     const scheduledCourse: ScheduledCourse = { ...course, color }
     setScheduledCourses([...scheduledCourses, scheduledCourse])
   }


### PR DESCRIPTION
## Summary
- reuse the first available schedule color when adding a course after removing others
- run vitest tests

## Testing
- `pnpm exec vitest run`

------
https://chatgpt.com/codex/tasks/task_e_688997b2b0a08330a42ed8388c904c45