### PR TITLE
Display session in calendar entries

### DIFF
--- a/app/page.tsx
+++ b/app/page.tsx
@@ -1095,6 +1095,11 @@ export default function SOMCourse() {
                             >
                               <div className="font-medium">{course.courseNumber}</div>
                               <div className="truncate">{course.courseTitle}</div>
+                              {course.courseSession && (
+                                <div className="text-xs opacity-90">
+                                  {course.courseSession}
+                                </div>
+                              )}
                               <div className="text-xs opacity-90">{course.room}</div>
                             </div>
                           ))}


### PR DESCRIPTION
## Summary
- add course session info to calendar view when displaying scheduled courses

## Testing
- `pnpm exec vitest run`

------
https://chatgpt.com/codex/tasks/task_e_68899d321c048330826be371a36da656