### PR TITLE
Capitalize course session labels

### DIFF
--- a/app/page.tsx
+++ b/app/page.tsx
@@ -15,6 +15,7 @@ import { Popover, PopoverContent, PopoverTrigger } from "@/components/ui/popover
 import { Checkbox } from "@/components/ui/checkbox"
 import { Table, TableBody, TableCell, TableHead, TableHeader, TableRow } from "@/components/ui/table"
 import { generateICS } from "@/lib/ics"
+import { capitalize } from "@/lib/utils"
 
 interface Instructor {
   name: string
@@ -270,7 +271,9 @@ const processCourseData = (course: any): Course => {
   return {
     ...course,
     termCode: course.termCode || "unknown",
-    courseSession: course.courseSession?.trim() || course.courseSession,
+    courseSession: course.courseSession
+      ? capitalize(course.courseSession.trim())
+      : course.courseSession,
     courseCategories: categories,
     instructors: instructors,
     meetingDays: meetingDays,
@@ -616,7 +619,7 @@ export default function SOMCourse() {
     const cats = searchParams.get("categories")
     if (cats) setSelectedCategories(cats.split(",").filter(Boolean))
     const sess = searchParams.get("sessions")
-    if (sess) setSelectedSessions(sess.split(",").filter(Boolean))
+    if (sess) setSelectedSessions(sess.split(",").filter(Boolean).map(capitalize))
     const instr = searchParams.get("instructors")
     if (instr) setSelectedInstructors(instr.split(",").filter(Boolean))
     const unitsParam = searchParams.get("units")

--- a/lib/utils.ts
+++ b/lib/utils.ts
@@ -4,3 +4,7 @@ import { twMerge } from "tailwind-merge"
 export function cn(...inputs: ClassValue[]) {
   return twMerge(clsx(inputs))
 }
+
+export function capitalize(str: string): string {
+  return str ? str.charAt(0).toUpperCase() + str.slice(1) : ""
+}


### PR DESCRIPTION
## Summary
- add `capitalize` helper
- show course sessions with capitalized first letter

## Testing
- `pnpm exec vitest run`


------
https://chatgpt.com/codex/tasks/task_e_688adb575e648330a68762561f98ea0e