### PR TITLE
Match add button color to header

### DIFF
--- a/app/page.tsx
+++ b/app/page.tsx
@@ -984,7 +984,9 @@ export default function SOMCourse() {
                 }
               }}
               size="icon"
-              className="ml-4 h-8 w-8 flex-shrink-0"
+              className={`ml-4 h-8 w-8 flex-shrink-0 ${
+                isScheduled ? '' : 'bg-[#000f9f] text-white hover:bg-[#000f9f]/90'
+              }`}
             >
               {isScheduled ? <Minus className="w-4 h-4" /> : <Plus className="w-4 h-4" />}
             </Button>


### PR DESCRIPTION
## Summary
- update the course add button so its fill matches the SOM header color

## Testing
- `pnpm exec vitest run`


------
https://chatgpt.com/codex/tasks/task_e_688ae91607e88330bf6554adea6c0287