### PR TITLE
Set calendar view as default and update site title

### DIFF
--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -13,7 +13,7 @@ const inter = Inter({
 });
 
 export const metadata: Metadata = {
-  title: "SOM Course Picker",
+  title: "MySOMClasses",
   description: "Course selection website for Yale School of Management",
   generator: "v0.dev",
   icons: {

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -566,7 +566,7 @@ export default function SOMCourse() {
   const [scheduledCourses, setScheduledCourses] = useState<ScheduledCourse[]>([])
   const [searchTerm, setSearchTerm] = useState("")
   const [loading, setLoading] = useState(true)
-  const [activeTab, setActiveTab] = useState("table")
+  const [activeTab, setActiveTab] = useState("calendar")
   const [selectedCategories, setSelectedCategories] = useState<string[]>([])
   const [selectedSessions, setSelectedSessions] = useState<string[]>([])
   const [selectedInstructors, setSelectedInstructors] = useState<string[]>([])
@@ -1005,7 +1005,7 @@ export default function SOMCourse() {
       <header className="bg-white border-b border-gray-200 px-6 py-4">
         <div className="flex items-center justify-between">
           <h1 className="text-2xl font-bold text-gray-900">
-            <span className="text-[#000f9f]">SOM</span>Course
+            My<span className="text-[#000f9f]">SOM</span>Classes
           </h1>
           <div className="flex items-center space-x-2">
             <Button
@@ -1043,13 +1043,13 @@ export default function SOMCourse() {
           <Tabs value={activeTab} onValueChange={setActiveTab} className="w-full">
             <div className="flex justify-center mb-4">
               <TabsList>
-                <TabsTrigger value="table" className="flex items-center">
-                  <TableIcon className="w-4 h-4 mr-2" />
-                  Table
-                </TabsTrigger>
                 <TabsTrigger value="calendar" className="flex items-center">
                   <Calendar className="w-4 h-4 mr-2" />
                   Calendar
+                </TabsTrigger>
+                <TabsTrigger value="table" className="flex items-center">
+                  <TableIcon className="w-4 h-4 mr-2" />
+                  Table
                 </TabsTrigger>
               </TabsList>
             </div>


### PR DESCRIPTION
## Summary
- Default to calendar view on load
- Rebrand site title to MySOMClasses with blue SOM highlight
- Show calendar tab to the left of table tab

## Testing
- `pnpm lint` *(fails: How would you like to configure ESLint?)*
- `pnpm vitest run`


------
https://chatgpt.com/codex/tasks/task_e_688eb391d88c833088ec4e977dc10fcd