### PR TITLE
Link instructors to faculty pages

### DIFF
--- a/app/page.tsx
+++ b/app/page.tsx
@@ -16,6 +16,7 @@ import { Checkbox } from "@/components/ui/checkbox"
 import { Table, TableBody, TableCell, TableHead, TableHeader, TableRow } from "@/components/ui/table"
 import { generateICS } from "@/lib/ics"
 import { capitalize } from "@/lib/utils"
+import { facultyUrlFromName } from "@/lib/faculty"
 
 interface Instructor {
   name: string
@@ -900,9 +901,9 @@ export default function SOMCourse() {
         details.push(
           <a
             key={instructor.name}
-            href={`mailto:${instructor.email}`}
+            href={facultyUrlFromName(instructor.name)}
             className="text-gray-500 hover:text-gray-700 underline"
-            title={`Email ${instructor.name}`}
+            title={`View ${instructor.name}'s faculty page`}
           >
             {instructor.name}
           </a>,
@@ -1091,18 +1092,17 @@ export default function SOMCourse() {
                           <TableCell>{course.courseSession}</TableCell>
                           <TableCell>{course.courseCategories.join(", ")}</TableCell>
                           <TableCell>
-                            {course.instructors.map((instructor) => (
-                              <div key={instructor.email}>
+                              {course.instructors.map((instructor) => (
                                 <a
-                                  href={`mailto:${instructor.email}`}
-                                  className="text-gray-600 hover:underline"
-                                  title={`Email ${instructor.name}`}
+                                  key={instructor.name}
+                                  href={facultyUrlFromName(instructor.name)}
+                                  className="block text-gray-600 hover:underline"
+                                  title={`View ${instructor.name}'s faculty page`}
                                 >
                                   {instructor.name}
                                 </a>
-                              </div>
-                            ))}
-                          </TableCell>
+                              ))}
+                            </TableCell>
                           <TableCell>{course.daysTimes}</TableCell>
                           <TableCell>{course.room}</TableCell>
                           <TableCell>{course.units}</TableCell>

--- a/lib/faculty.test.ts
+++ b/lib/faculty.test.ts
@@ -1,0 +1,20 @@
+import { describe, it, expect } from 'vitest'
+import { facultyUrlFromName } from './faculty'
+
+describe('facultyUrlFromName', () => {
+  it('converts "Ghosh, Asha" to profile URL', () => {
+    expect(facultyUrlFromName('Ghosh, Asha')).toBe(
+      'https://som.yale.edu/faculty-research/faculty-directory/asha-ghosh'
+    )
+  })
+
+  it('handles initials and punctuation', () => {
+    expect(facultyUrlFromName('Wasserstein, A.J.')).toBe(
+      'https://som.yale.edu/faculty-research/faculty-directory/aj-wasserstein'
+    )
+  })
+
+  it('returns # for malformed names', () => {
+    expect(facultyUrlFromName('SingleName')).toBe('#')
+  })
+})

--- a/lib/faculty.ts
+++ b/lib/faculty.ts
@@ -1,0 +1,11 @@
+export function facultyUrlFromName(name: string) {
+  const [last, first] = name.split(',').map((part) => part.trim())
+  if (!first || !last) return '#'
+  const slugify = (str: string) =>
+    str
+      .toLowerCase()
+      .replace(/\./g, '')
+      .replace(/['’]/g, '')
+      .replace(/\s+/g, '-')
+  return `https://som.yale.edu/faculty-research/faculty-directory/${slugify(first)}-${slugify(last)}`
+}


### PR DESCRIPTION
## Summary
- ensure instructor links use faculty directory URLs keyed by instructor name
- extract URL generation into helper with tests verifying faculty URLs

## Testing
- `pnpm lint` *(fails: prompts to configure ESLint)*
- `pnpm test --run`


------
https://chatgpt.com/codex/tasks/task_e_688ec619ca7c8330838a64827c3d01f0