### PR TITLE
Remove implicit "Elective" default for program/cohort filter

### DIFF
--- a/app/page.tsx
+++ b/app/page.tsx
@@ -684,7 +684,7 @@ export default function SOMCourse() {
     const pc = searchParams.get("programs")
     if (pc) setSelectedProgramCohorts(pc.split(",").filter(Boolean))
     if (!hasParams) {
-      setSelectedProgramCohorts(["Elective"])
+      setSelectedProgramCohorts([])
     }
     const search = searchParams.get("search")
     if (search) setSearchTerm(search)


### PR DESCRIPTION
### Motivation
- Remove the implicit `Elective` program/cohort filter when the app is loaded with no URL query parameters so the default filter state is empty.

### Description
- Update initialization in `app/page.tsx` to call `setSelectedProgramCohorts([])` instead of `setSelectedProgramCohorts(["Elective"])` when no query params are present, while preserving explicit `programs` query param behavior.

### Testing
- Ran `npm run lint` (success; non-blocking React hook dependency warnings remain) and executed an automated Playwright script against the local dev server to capture a UI screenshot verifying the empty default program filter (both steps succeeded).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a03ea225b483308e1fc811791c2fd7)