### PR TITLE
Nested sessions dropdown with parent grouping and top-level "Other"

### DIFF
--- a/app/page.tsx
+++ b/app/page.tsx
@@ -435,6 +435,12 @@ const SessionMultiSelectFilter = ({
   }
 
   const selectedCount = selected.filter((item) => allOptions.includes(item)).length
+  const optionLabelMap = new Map(
+    groups.flatMap((group) => group.children.map((child) => [child.id, child.label] as const))
+  )
+  const selectedLabels = selected
+    .filter((item) => allOptions.includes(item))
+    .map((item) => optionLabelMap.get(item) ?? item)
 
   return (
     <Popover>
@@ -444,7 +450,7 @@ const SessionMultiSelectFilter = ({
           className="w-full sm:w-40 justify-between text-left font-normal bg-transparent"
         >
           <span className="truncate">
-            {selectedCount === 0 ? placeholder : selectedCount === 1 ? "1 selected" : `${selectedCount} selected`}
+            {selectedCount === 0 ? placeholder : selectedLabels.join(", ")}
           </span>
           <ChevronDown className="ml-2 h-4 w-4 shrink-0" />
         </Button>


### PR DESCRIPTION
### Motivation
- Provide a nested Sessions filter so term/year parents (e.g. `Fall 2025`) can select all child sessions and handle non-standard session labels consistently.
- Keep compatibility with existing query-param session values while making session selection more discoverable and robust for calendar filtering.

### Description
- Added session typing and normalization helpers: `SessionFilterGroup`, `SessionFilterOption`, `SESSION_FORMAT_MAP`, `getSessionYear`, and `getCourseSessionFilterId` in `app/page.tsx` to map courses into stable session IDs (including `other:*`).
- Implemented a grouped session selector `SessionMultiSelectFilter` with parent checkboxes that toggle all children and child-level toggles, and replaced the flat sessions control with this nested control in the filters UI.
- Built `sessionFilterGroups` computation to group sessions by `term-year` (e.g. `Fall-2025`) and appended a top-level `Other` bucket for sessions that don't match the expected Fall/Spring formats.
- Updated initialization and filtering logic to accept the new session IDs from query params while remaining compatible with old plain session strings so filtering and calendar view behavior continue to work.

### Testing
- Ran unit tests with `npm test -- --run` and all tests passed (`3` test files, `19` tests). 
- Ran linter with `npm run lint` which completed; it reports pre-existing React hook dependency warnings but no new blocking errors.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a03f4cbd74833084274e17c7b15822)